### PR TITLE
Windows 10 support and error checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var os = require('os');
 
 var nameMap = {
-	'6.4': '10',
+	'10.0': '10',
 	'6.3': '8.1',
 	'6.2': '8',
 	'6.1': '7',
@@ -15,5 +15,11 @@ var nameMap = {
 };
 
 module.exports = function (release) {
-	return nameMap[(release || os.release()).slice(0, 3)];
+    var version = (release || os.release()).match(/\d+\.\d+/);
+
+    if (!version) {
+        throw new Error('\'release\' argument doesn\'t match \'nn.n\'');
+    }
+
+	return nameMap[version[0]];
 };


### PR DESCRIPTION
This will allow Windows 10 to be matched by win-release and os-name. Ofc package.json and versionning of both 'win-release' and 'os-name' will need to be incremented. 

https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx for more info about user-agent changes in windows 10.
