### PR TITLE
add note for old node versions to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ Type: `string`
 
 By default the current OS is used, but you can supply a custom release number, which is the output of [`os.release()`](http://nodejs.org/api/os.html#os_os_release).
 
+*Note: node.js versions lower than 3.1.0 will incorrectly identify Windows 10 as Windows 8.1.*
 
 ## Related
 


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/2332, not much to be done about that unfortunately, because Microsoft in their infinite wisdom decided to return a version from their previous OS, unless the app opts in.
