### PR TITLE
workaround os.release() issue on Windows 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var os = require('os');
+var semver = require('semver');
 
 var nameMap = {
 	'10.0': '10',
@@ -15,11 +16,21 @@ var nameMap = {
 };
 
 module.exports = function (release) {
-	var version = /\d+\.\d+/.exec(release || os.release());
+	var verRe = /\d+\.\d+/;
+	var version = verRe.exec(release || os.release());
 
-	if (!version) {
+	// workaround for Windows 10 on node < 3.1.0
+	if (!release && process.platform === 'win32' &&
+			semver.satisfies(process.version, '>=0.12.0')) {
+		var execSync = require('child_process').execSync;
+		try {
+			version = verRe.exec(String(execSync('ver.exe', {timeout: 2000})));
+		} catch (e) {}
+	}
+
+	if (release && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');
 	}
 
-	return nameMap[version[0]];
+	return nameMap[(version || [])[0]];
 };

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   ],
   "devDependencies": {
     "ava": "0.0.4"
+  },
+  "dependencies": {
+    "semver": "^5.0.1"
   }
 }


### PR DESCRIPTION
- Added a workaround, based on https://github.com/atom/electron/issues/2586#issuecomment-134913756.
- Added a safeguard on the `return` in case the regex doesn't match (unlikely).

`ver.exe` returns this string on Windows 10 for reference:

``` js
'\r\nMicrosoft Windows [Version 10.0.10240]\r\n'
```
