### PR TITLE
add upper limit for the Windows 10 workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (release) {
 
 	// workaround for Windows 10 on node < 3.1.0
 	if (!release && process.platform === 'win32' &&
-		semver.satisfies(process.version, '>=0.12.0')) {
+		semver.satisfies(process.version, '>=0.12.0 <3.1.0')) {
 		try {
 			version = verRe.exec(String(require('child_process').execSync('ver.exe', {timeout: 2000})));
 		} catch (err) {}


### PR DESCRIPTION
Looks like the issue with .exe builds of node wasn't actually real, so we can start relying on `os.release` starting with 3.1.0.

Ref: https://github.com/nodejs/node/issues/2617#issuecomment-139613061
