### PR TITLE
Add Windows Server detection and require Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable quote-props */
-
 'use strict';
 const os = require('os');
 const execa = require('execa');
@@ -20,8 +19,7 @@ const nameMap = {
 };
 
 module.exports = release => {
-	const verRe = /\d+\.\d+/;
-	const version = verRe.exec(release || os.release());
+	const version = /\d+\.\d+/.exec(release || os.release());
 
 	if (release && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');

--- a/index.js
+++ b/index.js
@@ -20,9 +20,8 @@ const nameMap = {
 };
 
 module.exports = release => {
-	const rel = release || os.release();
 	const verRe = /\d+\.\d+/;
-	const version = verRe.exec(rel);
+	const version = verRe.exec(release || os.release());
 
 	if (release && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ const nameMap = {
 	'4.0': '95'
 };
 
-module.exports = function (release) {
+module.exports = release => {
 	const rel = release || os.release();
 	const verRe = /\d+\.\d+/;
 	const version = verRe.exec(rel);
 
-	if (rel && !version) {
+	if (release && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');
 	}
 
@@ -32,8 +32,8 @@ module.exports = function (release) {
 
 	// Server 2008, 2012 and 2016 version are ambiguous with desktop release versions
 	if (!release && ['6.1', '6.2', '6.3', '10.0'].indexOf(ver) !== -1) {
-		const child = execa.sync('wmic', ['os', 'get', 'Caption']);
-		const year = ((child.stdout || '').match(/2008|2012|2016/) || [])[0];
+		const stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
+		const year = (stdout.match(/2008|2012|2016/) || [])[0];
 		if (year) {
 			return `Server ${year}`;
 		}

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = release => {
 
 	const ver = (version || [])[0];
 
-	// Server 2008, 2012 and 2016 version are ambiguous with desktop release versions
+	// Server 2008, 2012 and 2016 versions are ambiguous with desktop versions
 	if (!release && ['6.1', '6.2', '6.3', '10.0'].indexOf(ver) !== -1) {
 		const stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];

--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
-'use strict';
-var os = require('os');
-var semver = require('semver');
+/* eslint-disable quote-props */
 
-var nameMap = {
+'use strict';
+const os = require('os');
+const execa = require('execa');
+
+// Reference: https://www.gaijin.at/en/lstwinver.php
+const nameMap = {
 	'10.0': '10',
 	'6.3': '8.1',
 	'6.2': '8',
 	'6.1': '7',
 	'6.0': 'Vista',
+	'5.2': 'Server 2003',
 	'5.1': 'XP',
 	'5.0': '2000',
 	'4.9': 'ME',
@@ -16,20 +20,24 @@ var nameMap = {
 };
 
 module.exports = function (release) {
-	var verRe = /\d+\.\d+/;
-	var version = verRe.exec(release || os.release());
+	const rel = release || os.release();
+	const verRe = /\d+\.\d+/;
+	const version = verRe.exec(rel);
 
-	// workaround for Windows 10 on node < 3.1.0
-	if (!release && process.platform === 'win32' &&
-		semver.satisfies(process.version, '>=0.12.0 <3.1.0')) {
-		try {
-			version = verRe.exec(String(require('child_process').execSync('ver.exe', {timeout: 2000})));
-		} catch (err) {}
-	}
-
-	if (release && !version) {
+	if (rel && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');
 	}
 
-	return nameMap[(version || [])[0]];
+	const ver = (version || [])[0];
+
+	// Server 2008, 2012 and 2016 version are ambiguous with desktop release versions
+	if (!release && ['6.1', '6.2', '6.3', '10.0'].indexOf(ver) !== -1) {
+		const child = execa.sync('wmic', ['os', 'get', 'Caption']);
+		const year = ((child.stdout || '').match(/2008|2012|2016/) || [])[0];
+		if (year) {
+			return `Server ${year}`;
+		}
+	}
+
+	return nameMap[ver];
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -32,7 +32,7 @@
     "version"
   ],
   "dependencies": {
-    "semver": "^5.0.1"
+    "execa": "^0.7.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ Type: `string`
 
 By default the current OS is used, but you can supply a custom release number, which is the output of [`os.release()`](http://nodejs.org/api/os.html#os_os_release).
 
+Note: Most Windows Server versions cannot be detected based on the release number alone. There is runtime detection in place to work around this, but it will only be used if no argument is supplied.
 
 ## Related
 


### PR DESCRIPTION
- Detect Windows Server 2008, 2012 and 2016 via a `wmic` call
- Remove workaround for io.js 3 and older node versions
- ES2015ify

Fixes: https://github.com/sindresorhus/win-release/issues/5