### PR TITLE
Improve detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const names = new Map([
 ]);
 
 module.exports = release => {
-	const version = /\d+\.\d+/.exec(release || os.release());
+	const version = /\d+\.\d/.exec(release || os.release());
 
 	if (release && !version) {
 		throw new Error('`release` argument doesn\'t match `n.n`');

--- a/index.js
+++ b/index.js
@@ -26,8 +26,11 @@ module.exports = release => {
 
 	const ver = (version || [])[0];
 
-	// Server 2008, 2012 and 2016 versions are ambiguous with desktop versions
-	if (!release && ['6.1', '6.2', '6.3', '10.0'].indexOf(ver) !== -1) {
+	// Server 2008, 2012 and 2016 versions are ambiguous with desktop versions and must be detected at runtime.
+	// If release is omitted or we're on a windows system, and the version number is an ambiguous version
+	// Then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
+	// If the resulting caption contains the year 2008, 2012 or 2016, it is a server version, so return a server OS name.
+	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].indexOf(ver) !== -1) {
 		const stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];
 		if (year) {

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Type: `string`
 
 By default, the current OS is used, but you can supply a custom release number, which is the output of [`os.release()`](https://nodejs.org/api/os.html#os_os_release).
 
-Note: Most Windows Server versions cannot be detected based on the release number alone. There is runtime detection in place to work around this, but it will only be used if no argument is supplied.
+Note: Most Windows Server versions cannot be detected based on the release number alone. There is runtime detection in place to work around this, but it will only be used if no argument is supplied, or the supplied argument matches `os.release()`.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,7 +1,72 @@
 import test from 'ava';
 import m from '.';
 
-test(t => {
-	t.is(m('5.1.2600'), 'XP');
-	t.is(m('10.0.10240'), '10');
+// Test using versions strings sourced from https://www.gaijin.at/en/lstwinver.php
+
+test('Windows 95 versions are correctly matched', t => {
+	const expected = '95';
+	const versions = ['4.00.950', '4.00.1111', '4.03.1212', '4.03.1214'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 98 versions are correctly matched', t => {
+	const expected = '98';
+	const versions = ['4.10.1998', '4.10.2222'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows ME versions are correctly matched', t => {
+	const expected = 'ME';
+	const versions = ['4.90.2476', '4.90.3000'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 2000 versions are correctly matched', t => {
+	const expected = '2000';
+	const versions = ['5.0.2031', '5.0.2128', '5.0.2183', '5.0.2195'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows XP versions are correctly matched', t => {
+	const expected = 'XP';
+	const versions = ['5.1.2505', '5.1.2600', '5.1.2600.1105', '5.1.2600.2180'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows Server 2003 versions are correctly matched', t => {
+	const expected = 'Server 2003';
+	const versions = ['5.2.3541', '5.2.3590', '5.2.3660', '5.2.3718', '5.2.3763', '5.2.3790', '5.2.3790.1180', '5.2.3790.1218'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows Vista versions are correctly matched', t => {
+	const expected = 'Vista';
+	const versions = ['6.0.5270', '6.0.5308', '6.0.5342', '6.0.5365', '6.0.5381', '6.0.5384', '6.0.5456', '6.0.5472', '6.0.5536',
+		'6.0.5600.16384', '6.0.5700', '6.0.5728', '6.0.5744.16384', '6.0.5808', '6.0.5824', '6.0.5840', '6.0.6000.16386', '6.0.6000',
+		'6.0.6002'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 7 versions are correctly matched', t => {
+	const expected = '7';
+	const versions = ['6.1.7600.16385', '6.1.7600', '6.1.7601'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 8 versions are correctly matched', t => {
+	const expected = '8';
+	const versions = ['6.2.9200', '6.2.10211'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 8.1 versions are correctly matched', t => {
+	const expected = '8.1';
+	const versions = ['6.3.9200', '6.3.9600'];
+	versions.forEach(version => t.is(m(version), expected));
+});
+
+test('Windows 10 versions are correctly matched', t => {
+	const expected = '10';
+	const versions = ['10.0.10240', '10.0.10586', '10.0.14393'];
+	versions.forEach(version => t.is(m(version), expected));
 });


### PR DESCRIPTION
* Fixes #8 
* Add tests of real version strings to increase test coverage / confidence
* Tweak regex to work with win 95, 98 and ME.

Note: i don't actually develop on a windows machine, so i'm just assuming everything should just work as it is logically correct.  