### PR TITLE
Add PowerShell fallback for when `wmic` doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const windowsRelease = release => {
 
 	const ver = (version || [])[0];
 
-	// Server 2008, 2012 and 2016, 2019 versions are ambiguous with desktop versions and must be detected at runtime.
+	// Server 2008, 2012, 2016, and 2019 versions are ambiguous with desktop versions and must be detected at runtime.
 	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
 	// If `wmic` is obsoloete (later versions of Windows 10), use PowerShell instead.

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const windowsRelease = release => {
 		let stdout;
 		try {
 			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
-		} catch (error) {
+		} catch (_) {
 			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
 		}
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,12 @@ const windowsRelease = release => {
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
 	// If the resulting caption contains the year 2008, 2012 or 2016, it is a server version, so return a server OS name.
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
-		const stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
+		let stdout;
+		try {
+			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
+		} catch (error) {
+			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
+		}
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];
 		if (year) {
 			return `Server ${year}`;

--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ const windowsRelease = release => {
 
 	const ver = (version || [])[0];
 
-	// Server 2008, 2012 and 2016 versions are ambiguous with desktop versions and must be detected at runtime.
+	// Server 2008, 2012 and 2016, 2019 versions are ambiguous with desktop versions and must be detected at runtime.
 	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
-	// If the resulting caption contains the year 2008, 2012 or 2016, it is a server version, so return a server OS name.
+	// If `wmic` is obsoloete (later versions of Windows 10), use Powershell instead
+	// If the resulting caption contains the year 2008, 2012 or 2016, 2019 it is a server version, so return a server OS name.
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
 		let stdout;
 		try {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ const windowsRelease = release => {
 		} catch (error) {
 			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
 		}
+
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];
+		
 		if (year) {
 			return `Server ${year}`;
 		}

--- a/index.js
+++ b/index.js
@@ -34,13 +34,8 @@ const windowsRelease = release => {
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
 		let stdout;
 		try {
-<<<<<<< HEAD
-=======
-			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
-		} catch (_) {
->>>>>>> b8a7f9af029fe3e7671cf730fd26d056bec530ed
 			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
-		} catch (error) {
+		} catch (_) {
 			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		}
 

--- a/index.js
+++ b/index.js
@@ -34,9 +34,9 @@ const windowsRelease = release => {
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
 		let stdout;
 		try {
-			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
-		} catch (error) {
 			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
+		} catch (error) {
+			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		}
 
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const windowsRelease = release => {
 	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
 	// If `wmic` is obsoloete (later versions of Windows 10), use PowerShell instead.
-	// If the resulting caption contains the year 2008, 2012 or 2016, 2019, it is a server version, so return a server OS name.
+	// If the resulting caption contains the year 2008, 2012, 2016 or 2019, it is a server version, so return a server OS name.
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
 		let stdout;
 		try {
@@ -39,7 +39,7 @@ const windowsRelease = release => {
 			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		}
 
-		const year = (stdout.match(/2008|2012|2016/) || [])[0];
+		const year = (stdout.match(/2008|2012|2016|2019/) || [])[0];
 
 		if (year) {
 			return `Server ${year}`;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const windowsRelease = release => {
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
 	// If the resulting caption contains the year 2008, 2012 or 2016, it is a server version, so return a server OS name.
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
-		const stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
+		const stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];
 		if (year) {
 			return `Server ${year}`;

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ const windowsRelease = release => {
 	// Server 2008, 2012 and 2016, 2019 versions are ambiguous with desktop versions and must be detected at runtime.
 	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
-	// If `wmic` is obsoloete (later versions of Windows 10), use Powershell instead
-	// If the resulting caption contains the year 2008, 2012 or 2016, 2019 it is a server version, so return a server OS name.
+	// If `wmic` is obsoloete (later versions of Windows 10), use PowerShell instead.
+	// If the resulting caption contains the year 2008, 2012 or 2016, 2019, it is a server version, so return a server OS name.
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
 		let stdout;
 		try {

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const windowsRelease = release => {
 		}
 
 		const year = (stdout.match(/2008|2012|2016/) || [])[0];
-		
+
 		if (year) {
 			return `Server ${year}`;
 		}


### PR DESCRIPTION
I changed the line using WMIC to use Powershell instead.

So instead of running: wmic os get caption
it now use: powershell (Get-CimInstance -ClassName Win32_OperatingSystem).caption

It should do the exact same thing, and work on the latest versions of Windows 10.

Fixes #14 