### PR TITLE
Simple Windows 11 check, extended PowerShell func.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,26 +24,44 @@ export default function windowsRelease(release) {
 		throw new Error('`release` argument doesn\'t match `n.n`');
 	}
 
-	const ver = (version || [])[0];
+	let ver = (version || [])[0];
 
-	// Server 2008, 2012, 2016, and 2019 versions are ambiguous with desktop versions and must be detected at runtime.
+	// Server 2008, 2012, 2016, 2019 and 2022 versions are ambiguous with desktop versions and must be detected at runtime.
 	// If `release` is omitted or we're on a Windows system, and the version number is an ambiguous version
 	// then use `wmic` to get the OS caption: https://msdn.microsoft.com/en-us/library/aa394531(v=vs.85).aspx
-	// If `wmic` is obsolete (later versions of Windows 10), use PowerShell instead.
-	// If the resulting caption contains the year 2008, 2012, 2016 or 2019, it is a server version, so return a server OS name.
+	// If `wmic` is obsolete (later versions of Windows 10 as well as Windows 11), use PowerShell instead.
+	// Try PowerShell with `Get-CimInstance` (more future proof) first, else use `Get-WmiObject`.
+	// If the resulting caption contains the year 2008, 2012, 2016, 2019 or 2022, it is a server version, so return a server OS name.
+	// Since both Windows 10 and Windows 11 use the same version number (10.0), a check for Windows 11 is done.
+	let stdout;
+	let win11;
 	if ((!release || release === os.release()) && ['6.1', '6.2', '6.3', '10.0'].includes(ver)) {
-		let stdout;
 		try {
 			stdout = execa.sync('wmic', ['os', 'get', 'Caption']).stdout || '';
 		} catch {
-			stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).caption']).stdout || '';
+			try {
+				stdout = execa.sync('powershell', ['(Get-CimInstance -ClassName Win32_OperatingSystem).Caption']).stdout || '';
+			} catch {
+				stdout = execa.sync('powershell', ['(Get-WmiObject -ClassName Win32_OperatingSystem).Caption']).stdout || '';
+			}
 		}
 
-		const year = (stdout.match(/2008|2012|2016|2019/) || [])[0];
+		const year = (stdout.match(/2008|2012|2016|2019|2022/) || [])[0];
+		// Check to see if we run Windows 11
+		win11 = (stdout.match(/Windows 11/) || [])[0];
 
 		if (year) {
 			return `Server ${year}`;
 		}
+	}
+
+	// Windows 11 check, only needed if we use the `release* argument.
+	if (release && ver === '10.0' && release.split('.').slice(2)[0].startsWith('2')) {
+		win11 = 'Windows 11';
+	}
+
+	if (win11) {
+		ver = '11.0';
 	}
 
 	return names.get(ver);

--- a/test.js
+++ b/test.js
@@ -121,3 +121,12 @@ test('Windows 10 versions are correctly matched', t => {
 		t.is(windowsRelease(version), expected);
 	}
 });
+
+test('Windows 11 versions are correctly matched', t => {
+	const expected = '11';
+	const versions = ['10.0.22000'];
+
+	for (const version of versions) {
+		t.is(windowsRelease(version), expected);
+	}
+});


### PR DESCRIPTION
I added a simple check for Windows 11 and Windows Server 2022, and extended the PowerShell functionality by adding Get-WmiObject as a fallback (might be needed on older versions of Windows).